### PR TITLE
reconcile failed services again

### DIFF
--- a/controller/service.go
+++ b/controller/service.go
@@ -144,10 +144,10 @@ func (c *controller) convergeBalancer(l log.Logger, key string, svc *v1.Service)
 		if err != nil {
 			level.Error(l).Log("op", "allocateIPs", "error", err, "msg", "IP allocation failed")
 			c.client.Errorf(svc, "AllocationFailed", "Failed to allocate IP for %q: %s", key, err)
-			// The outer controller loop will retry converging this
-			// service when another service gets deleted, so there's
-			// nothing to do here but wait to get called again later.
-			return true
+			// we weren't able to allocate an IP so far, but we
+			// will add this service to the rate limited queue from
+			// where it will be reconciled again
+			return false
 		}
 		level.Info(l).Log("event", "ipAllocated", "ip", lbIPs, "msg", "IP address assigned by controller")
 		c.client.Infof(svc, "IPAllocated", "Assigned IP %q", lbIPs)


### PR DESCRIPTION
In our prehistoric version of metalLB, k8s services are only reconciled again once another service got deleted (maybe an IP was freed by this). This does not play well with our metallb configurator which might add an IP address to the metalLB configMap only after it has already been tried to be allocated.